### PR TITLE
Turtle fails to reject when a process crashes.

### DIFF
--- a/src/turtle_service.erl
+++ b/src/turtle_service.erl
@@ -71,7 +71,7 @@ init([#{ name := Name } = Conf]) ->
         {pool,
             {turtle_subscriber_pool, start_link, [Name]},
             transient, infinity, supervisor, [turtle_subscriber_pool]},
-    {ok, { { one_for_all, 5, 3600}, [Pool, ChanMgr]}}.
+    {ok, { { one_for_all, 50, 3600}, [Pool, ChanMgr]}}.
     
 validate_config(#{
 	name := N,

--- a/src/turtle_service.erl
+++ b/src/turtle_service.erl
@@ -71,7 +71,7 @@ init([#{ name := Name } = Conf]) ->
         {pool,
             {turtle_subscriber_pool, start_link, [Name]},
             transient, infinity, supervisor, [turtle_subscriber_pool]},
-    {ok, { { one_for_all, 50, 3600}, [Pool, ChanMgr]}}.
+    {ok, { { one_for_all, 5, 3600}, [ChanMgr, Pool]}}.
     
 validate_config(#{
 	name := N,

--- a/src/turtle_subscriber_pool.erl
+++ b/src/turtle_subscriber_pool.erl
@@ -34,7 +34,7 @@ init([]) ->
     SubChild =
         {subscriber,
             {turtle_subscriber, start_link, []},
-            transient, 15*1000, worker, [turtle_subscriber]},
+            permanent, 15*1000, worker, [turtle_subscriber]},
 
     {ok, { { simple_one_for_one, 100, 3600}, [SubChild]}}.
 

--- a/test/turtle_SUITE.erl
+++ b/test/turtle_SUITE.erl
@@ -31,11 +31,12 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(rpc_dbg_disable, Config) ->
+init_per_testcase(xfaulty_service, Config) ->
     dbg:tracer(),
     dbg:p(all, c),
     dbg:tpl(turtle_subscriber, '_', '_', cx),
     dbg:tpl(amqp_channel, cast, '_', cx),
+    dbg:tpl(amqp_channel, call, '_', cx),
     Config;
 init_per_testcase(send_recv, Config) ->
     exometer:delete([amqp_server, local_publisher, casts]),
@@ -43,7 +44,7 @@ init_per_testcase(send_recv, Config) ->
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(rpc_dbg_disable, _Config) ->
+end_per_testcase(xfaulty_service, _Config) ->
     dbg:stop_clear(),
     ok;
 end_per_testcase(_Case, _Config) ->
@@ -259,14 +260,11 @@ faulty_service(_Config) ->
     
     ct:log("Add a faulty subscriber, consuming on Q"),
     Self = self(),
-    F = fun(Key, ContentType, Payload, _State) ->
-        case random:uniform() < 0.5 of
-            true ->
-                error(foo);
-            false ->
-                Self ! {Key, ContentType, Payload},
-                ack
-        end
+    F = fun
+        (_Key, _ContentType, <<"Fail">>, _State) -> error(fail);
+        (Key, ContentType, Payload, _State) ->
+            Self ! {Key, ContentType, Payload},
+            ack
     end,
     
     {ok, _ServicePid} = turtle_service:start_link(
@@ -279,7 +277,7 @@ faulty_service(_Config) ->
                 #'queue.declare' { queue = Q },
                 #'queue.bind' { queue = Q, exchange = X, routing_key = Q }],
             subscriber_count => 3,
-            prefetch_count => 10,
+            prefetch_count => 5,
             consume_queue => Q
         }),
 
@@ -296,11 +294,13 @@ faulty_service(_Config) ->
 
     ct:log("Publish some messages on the channel:"),
     [
+        turtle:publish(local_publisher, X, Q, <<"text/plain">>, <<"Fail">>)
+        || _ <- lists:seq(1, 3)],
+    [
         turtle:publish(local_publisher, X, Q, <<"text/plain">>, <<"The turtle and the hare">>)
-        || _ <- lists:seq(1, 10)],
-    ok = turtle:publish_sync(local_publisher, X, Q, <<"text/plain">>, <<"The hare and the turtle">>),
+        || _ <- lists:seq(1, 7)],
 
-    ok = faulty_receive(11),
+    ok = faulty_receive(7),
     ok.
 
 kill_service(_Config) ->
@@ -462,6 +462,6 @@ faulty_receive(N) ->
         {_, <<"text/plain">>, <<"The turtle and the hare">>} ->
             ct:pal("Got message for N=~B", [N]),
             faulty_receive(N-1)
-    after 10*1000 ->
+    after 15*1000 ->
         ct:fail(subscription_timeout)
     end.


### PR DESCRIPTION
Here is the problem: If a handler crashes, we see a message which is still unacked, but it is lost in the void and will never be acked correctly. We need to handle this case.

First part of the game is to introduce a test case which fails.