### PR TITLE
Handle other connection failure reasons

### DIFF
--- a/src/turtle_conn.erl
+++ b/src/turtle_conn.erl
@@ -123,6 +123,11 @@ handle_info(connect,
             lager:warning("Timeout while connecting to RabbitMQ, retrying in ~Bs: ~p",
                 [Retry div 1000, group_report(CG)]),
             erlang:send_after(Retry, self(), connect),
+            {noreply, NextState};
+        {error, Reason, #state { cg = CG } = NextState} ->
+            lager:warning("Error connecting to RabbitMQ, reason: ~p, retrying in ~Bs: ~p",
+                [Reason, Retry div 1000, group_report(CG)]),
+            erlang:send_after(Retry, self(), connect),
             {noreply, NextState}
     end;
 handle_info(_, State) ->


### PR DESCRIPTION
I often receive {error,{socket_closed_unexpectedly,'connection.start'}} when calling amqp_connection:start/1 against RabbitMQ 3.5.6 while it is starting up or shutting down.  This change adds a fallback retry for this and other unexpected failure reasons instead of crashing.

Without this change, starting and stopping my RabbitMQ nodes while turtle was pointed at it would reliably bring down the whole node.  On my systems, the issue is quite easy to replicate if I enable HiPE compilation at startup, but it also seems easy to replicate during shutdown.