### PR TITLE
Jl/feature/bulk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ this number may become better over time. It is unlikely to become worse.
 
 # Changes
 
-* *Version 1.7.0* (**In progress**)— Refactoring of service channels
+* *Version 1.7.0* — Bulk messaging support
+
+    - *Potential incompatibility:* The `handle_info/2` callback when doing subscription services can now be called in more situations. Make sure your callback handle unknown messages by ignoring them. Otherwise your service may fail.
+    
+    - Add support for handling messages in bulk. See the appropriate section in the README file in order to use it.
 
     - Implement a change where `turtle_cannel` is renamed into `turtle_service_mgr` and draws no channels by itself. Rather, channels is now the domain of `turtle_subscriber`. This change moves the channel scope onto individual processes, which opens the design space for further improvement.
 

--- a/src/turtle.erl
+++ b/src/turtle.erl
@@ -263,9 +263,10 @@ consume(Channel, Queue) ->
 %% @end
 %% @private
 cancel(Channel, Tag) ->
-   Cancel = #'basic.cancel' { consumer_tag = Tag },
-   #'basic.cancel_ok' {} = amqp_channel:call(Channel, Cancel),
-   ok.
+    Cancel = #'basic.cancel' { consumer_tag = Tag },
+    #'basic.cancel_ok' {} = amqp_channel:call(Channel, Cancel),
+    ok.
+
 
 %% @doc qos/2 set QoS parameters on a queue according to configuration
 %% @end

--- a/src/turtle_service.erl
+++ b/src/turtle_service.erl
@@ -94,13 +94,7 @@ validate_config(#{
       is_integer(SC), SC > 0,
       is_integer(PC), PC >= 0,
       is_binary(Q) ->
-	ok = mode_ok(Conf),
-	ok = timeout_ok(Conf).
+	ok = mode_ok(Conf).
 
 mode_ok(#{ mode := Mode }) when Mode == bulk; Mode == single -> ok;
 mode_ok(#{}) -> ok.
-
-timeout_ok(#{ timeout := infinity }) -> ok;
-timeout_ok(#{ timeout := Ms}) when is_integer(Ms) -> ok;
-timeout_ok(#{ timeout := _Wrong }) -> exit(invalid_config);
-timeout_ok(#{}) -> ok.

--- a/src/turtle_service.erl
+++ b/src/turtle_service.erl
@@ -84,7 +84,7 @@ validate_config(#{
 	declarations := Decls,
 	subscriber_count := SC,
 	prefetch_count := PC,
-	consume_queue := Q })
+	consume_queue := Q } = Conf)
     when
       is_atom(N),
       is_atom(C),
@@ -94,5 +94,7 @@ validate_config(#{
       is_integer(SC), SC > 0,
       is_integer(PC), PC >= 0,
       is_binary(Q) ->
-      	ok.
+      	mode_ok(Conf).
 
+mode_ok(#{ mode := Mode }) when Mode == bulk; Mode == single -> ok;
+mode_ok(#{}) -> ok.

--- a/src/turtle_service.erl
+++ b/src/turtle_service.erl
@@ -94,7 +94,13 @@ validate_config(#{
       is_integer(SC), SC > 0,
       is_integer(PC), PC >= 0,
       is_binary(Q) ->
-      	mode_ok(Conf).
+	ok = mode_ok(Conf),
+	ok = timeout_ok(Conf).
 
 mode_ok(#{ mode := Mode }) when Mode == bulk; Mode == single -> ok;
 mode_ok(#{}) -> ok.
+
+timeout_ok(#{ timeout := infinity }) -> ok;
+timeout_ok(#{ timeout := Ms}) when is_integer(Ms) -> ok;
+timeout_ok(#{ timeout := _Wrong }) -> exit(invalid_config);
+timeout_ok(#{}) -> ok.

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -345,7 +345,7 @@ delivery_tag({Tag, _ReplyTo, _CorrID}) -> Tag.
 
 shutdown(Reason, #state { handle_info = HandleInfo, invoke_state = IState } = State) ->
     S = turtle_time:monotonic_time(),
-    try HandleInfo(Reason, IState) of
+    try HandleInfo({amqp_shutdown, Reason}, IState) of
         {ok, IState2} -> {noreply, State#state { invoke_state = IState2 }};
         {Cmds, IState2} when is_list(Cmds) ->
             {stop, Reason,

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -82,9 +82,9 @@ handle_call(Call, From, State) ->
     {reply, {error, unknown_call}, State}.
 
 %% @private
-handle_cast(Cast, State) ->
+handle_cast(Cast, #state { timeout = T } = State) ->
     lager:warning("Unknown cast: ~p", [Cast]),
-    {noreply, State}.
+    {noreply, State, T}.
 
 %% @private
 handle_info(#'basic.consume_ok'{}, State) ->
@@ -189,7 +189,8 @@ handle_deliver_single({#'basic.deliver' {delivery_tag = Tag, routing_key = Key},
            {stop, {Class, Error}, State}
     end.
 
-handle_commands(_S, [], State) -> {noreply, State};
+handle_commands(_S, [], #state { timeout = T } = State) ->
+    {noreply, State, T};
 handle_commands(S, [C | Next],
 	#state { channel = Channel, conn_name = CN, name = N } = State) ->
     case C of

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -13,10 +13,6 @@
 	start_link/1
 ]).
 
-%% API
--export([
-]).
-
 -export([
     init/1,
     handle_call/3,
@@ -252,7 +248,7 @@ handle_commands(S, [C | Next],
         {{stop, Reason}, Tag} ->
             ok = amqp_channel:cast(Channel,
             	#'basic.reject' { delivery_tag = delivery_tag(Tag), requeue = true }),
-            {stop, Reason, shutdown(Reason, State)}
+            {stop, Reason, State}
     end.
 
 handle_message(Tag, Fun, Key,

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -201,6 +201,13 @@ handle_commands(S, [C | Next],
                 turtle_time:convert_time_unit(E-S, native, milli_seconds)),
            ok = amqp_channel:cast(Channel, #'basic.ack' { delivery_tag = Tag }),
            handle_commands(S, Next, State);
+       {bulk_ack, Tag} ->
+            E = turtle_time:monotonic_time(),
+            exometer:update([CN, N, msgs], 1),
+            exometer:update([CN, N, latency],
+                turtle_time:convert_time_unit(E-S, native, milli_seconds)),
+           ok = amqp_channel:cast(Channel, #'basic.ack' { delivery_tag = Tag, multiple = true }),
+           handle_commands(S, Next, State);
        {reject, Tag} ->
            exometer:update([CN, N, rejects], 1),
            ok = amqp_channel:cast(Channel,

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -34,7 +34,8 @@
 	handle_info = undefined,
 	channel,
 	channel_ref,
-	consumer_tag
+	consumer_tag,
+	mode = single
  }).
 
 %% LIFETIME MAINTENANCE
@@ -60,6 +61,7 @@ init([#{
     ok = turtle:declare(Ch, Decls, #{ passive => Passive }),
     {ok, Tag} = turtle:consume(Ch, Queue),
     MRef = monitor(process, Ch),
+    Mode = mode(Conf),
     {ok, #state {
         consumer_tag = Tag, 
         invoke = Fun,
@@ -68,7 +70,8 @@ init([#{
         channel = Ch,
         channel_ref = MRef,
         conn_name = ConnName,
-        name = Name }}.
+        name = Name,
+        mode = Mode }}.
 
 %% @private
 handle_call(Call, From, State) ->
@@ -238,3 +241,7 @@ drain_reject_messages(Channel) ->
     after 0 ->
         ok
     end.
+
+mode(#{ mode := bulk }) -> bulk;
+mode(#{ mode := single }) -> single;
+mode(#{}) -> single.

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -224,7 +224,7 @@ handle_commands(S, [C | Next],
            ok = amqp_channel:cast(Channel, #'basic.ack' { delivery_tag = delivery_tag(Tag), multiple = true }),
            handle_commands(S, Next, State);
        {bulk_nack, Tag} ->
-           E = turtle_time:monotic_time(),
+           E = turtle_time:monotonic_time(),
             exometer:update([CN, N, msgs], 1),
             exometer:update([CN, N, latency],
                 turtle_time:convert_time_unit(E-S, native, milli_seconds)),

--- a/test/turtle_SUITE.erl
+++ b/test/turtle_SUITE.erl
@@ -67,8 +67,8 @@ basic_group() ->
 
 groups() ->
     lists:append([
-      lifetime_group(),
-      basic_group()
+       lifetime_group(),
+       basic_group()
     ]).
 
 all() -> [
@@ -333,9 +333,9 @@ kill_service(_Config) ->
     flush(),
     ct:log("Kill the connection, check that the service goes away"),
     _ConnPid = gproc:where({n,l,{turtle,connection, amqp_server}}),
-    ChanPid = gproc:where({n,l,{turtle,service_channel,local_service}}),
-    MRef = erlang:monitor(process, ChanPid),
-    true = (ChanPid /= undefined),
+    MgrPid = gproc:where({n,l,{turtle,service_channel,local_service}}),
+    MRef = erlang:monitor(process, MgrPid),
+    true = (MgrPid /= undefined),
     turtle_conn:close(amqp_server),
     receive
         {'DOWN', MRef, process, _, Reason} ->
@@ -356,8 +356,8 @@ kill_service(_Config) ->
     ct:log("Await the start of the publisher"),
     gproc:await({n,l,{turtle,publisher,local_publisher}}, 300),
     ct:log("Check that the process got restarted and re-registered itself"),
-    ChanPid2 = gproc:await({n,l,{turtle,service_channel,local_service}}, 300),
-    true = ChanPid /= ChanPid2,
+    MgrPid2 = gproc:await({n,l,{turtle,service_channel,local_service}}, 300),
+    true = MgrPid /= MgrPid2,
 
     ct:log("Publish a message on the channel"),
     M = term_to_binary({msg, random:uniform(16#FFFF)}),


### PR DESCRIPTION
This work-in-progress implements bulk operations on the subscribers. It allows a worker to "delay" processing of messages until either a timeout or a certain condition has been met and then ack all the messages in bulk.

It allows users to turn a stream of messages into a "microbatch" which can then be sent to a batch-API.
