### PR TITLE
Fix the easy random -> rand changes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,17 +1,12 @@
 {erl_opts, [
     debug_info,
     {parse_transform, lager_transform}
-
 ]}.
 
 {deps, [
     {lager, {git, "https://github.com/basho/lager", {tag, "3.2.1"}}},
-
-    {rabbit_common,
-        {git, "https://github.com/jbrisbin/rabbit_common.git", {ref, "80814606ae23cc820c74e"}}},
-    {amqp_client,
-        {git, "https://github.com/jbrisbin/amqp_client.git", {ref, "a509e5d4d731d6edeb75"}}},
-    
+    {rabbit_common, {git, "https://github.com/jbrisbin/rabbit_common.git", {ref, "80814606ae23cc820c74e"}}},
+    {amqp_client, {git, "https://github.com/jbrisbin/amqp_client.git", {tag, "rabbitmq-3.6.2"}}},
     {exometer_core, {git, "https://github.com/Feuerlabs/exometer_core.git", {tag, "1.4"}}},
     {gproc, {git, "https://github.com/uwiger/gproc", {branch, "master"}}},
     {uuid, {git, "https://github.com/okeuday/uuid", {branch, "master"}}}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"amqp_client">>,
   {git,"https://github.com/jbrisbin/amqp_client.git",
-       {ref,"a509e5d4d731d6edeb755bd0f59250ebaf1f0130"}},
+       {ref,"d50aec00b94f0766a048b4eceaf25ddfdeeb1d86"}},
   0},
  {<<"bear">>,
   {git,"git://github.com/boundary/bear.git",

--- a/test/turtle_SUITE.erl
+++ b/test/turtle_SUITE.erl
@@ -321,7 +321,6 @@ send_recv(_Config) ->
     ok.
 
 faulty_service(_Config) ->
-    random:seed(),
     X = <<"send_recv_exchange">>,
     Q = <<"send_recv_queue">>,
 
@@ -371,7 +370,6 @@ faulty_service(_Config) ->
     ok.
 
 kill_service(_Config) ->
-    random:seed(),
     X = <<"send_recv_exchange">>,
     Q = <<"send_recv_queue">>,
 
@@ -427,7 +425,7 @@ kill_service(_Config) ->
     true = MgrPid /= MgrPid2,
 
     ct:log("Publish a message on the channel"),
-    M = term_to_binary({msg, random:uniform(16#FFFF)}),
+    M = term_to_binary({msg, rand:uniform(16#FFFF)}),
     turtle:publish(local_publisher, X, Q, <<"text/plain">>, M),
     receive
         {Q, <<"text/plain">>, M} ->
@@ -493,7 +491,6 @@ get_msgs() ->
 
 run_many_rpc(Workers, K) ->
     F = fun() ->
-         random:seed(erlang:timestamp()),
          rpc_worker_loop(K),
          ct:log("Worker done"),
          ok
@@ -518,7 +515,7 @@ rpc_worker_loop(K) ->
     X = <<"rpc_exchange">>,
     Q = <<"rpc_queue">>,
 
-    I = random:uniform(10000),
+    I = rand:uniform(10000),
     {ok, _, <<"ctype">>, <<I:64/integer>>} =
         turtle:rpc_sync(local_publisher, X, Q, <<"ctype">>, <<I:64/integer>>),
     rpc_worker_loop(K-1).


### PR DESCRIPTION
Upgrade `amqp_client` and ct suite.

`rabbit_common` and `exometer_core` still need to be upgraded to versions that doesn't use the deprecated random module.