### PR TITLE
Handle Conns/Chans/Consumers through a janitor process

### DIFF
--- a/src/turtle.erl
+++ b/src/turtle.erl
@@ -318,7 +318,8 @@ qos(_Ch, _Conf) -> ok.
 %% @private
 -spec open_channel(atom()) -> {ok, channel()} | {error, Reason}
     when Reason :: term().
-open_channel(Name) -> turtle_conn:open_channel(Name).
+open_channel(Name) ->
+    turtle_conn:open_channel(Name).
 
 %% @doc declare(Ch, Decls) declares a list of idempotent setup for the Channel/RabbitMQ
 %% The RabbitMQ declaration stack is nasty because it returns different results for different

--- a/src/turtle_janitor.erl
+++ b/src/turtle_janitor.erl
@@ -1,0 +1,110 @@
+%%%-------------------------------------------------------------------
+%%% @author Jesper Louis Andersen <jesper.louis.andersen@gmail.com>
+%%% @copyright (C) 2017, Jesper Louis Andersen
+%%% @doc Maintain connections, channels and consumers
+%%%
+%%% @end
+%%% Created : 14 Jul 2017 by Jesper Louis Andersen <jesper.louis.andersen@gmail.com>
+%%%-------------------------------------------------------------------
+-module(turtle_janitor).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+-export([open_channel/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, { bimap = #{} }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+open_channel(Name) ->
+    gen_server:call(?SERVER, {open_channel, Name}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    process_flag(trap_exit, true),
+    {ok, #state{}}.
+
+
+handle_call({open_channel, Name}, {Pid, _}, #state { bimap = BiMap } = State) ->
+    case turtle_conn:open_channel(Name) of
+        {ok, Channel} ->
+            %% Hand out a channel to Pid
+            MRef = erlang:monitor(process, Pid),
+            {reply,
+             {ok, Channel},
+             State#state { bimap = bimap_put({channel, Channel}, MRef, BiMap) }};
+        Err ->
+            {reply, Err, State}
+    end;
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', MRef, process, _Pid, _},
+            #state { bimap = BiMap } = State) ->
+    {Val, Cleaned} = bimap_take(MRef, BiMap),
+    ok = cleanup(Val),
+    {noreply, State#state { bimap = Cleaned }};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+cleanup({channel, Ch}) ->
+    catch amqp_channel:close(Ch),
+    ok;
+cleanup({connection, Conn}) ->
+    catch amqp_connection:close(Conn),
+    ok;
+cleanup(not_found) ->
+    ok.
+
+bimap_take(X, Map) ->
+    case maps:take(X, Map) of
+        error ->
+            {not_found, Map};
+        Val ->
+            {Val, maps:remove(Val, Map)}
+    end.
+
+bimap_put(X, Y, Map) ->
+    M1 = maps:put(X, Y, Map),
+    M2 = maps:put(Y, X, M1),
+    M2.
+
+%% bimap_remove(X, Map) ->
+%%     case maps:get(X, Map, '$$$') of
+%%         '$$$' ->
+%%             Map;
+%%         Y ->
+%%             M1 = maps:remove(X, Map),
+%%             M2 = maps:remove(Y, Map),
+%%             M2
+%%     end.
+

--- a/src/turtle_sup.erl
+++ b/src/turtle_sup.erl
@@ -30,8 +30,15 @@ start_link() ->
 
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
+    Janitor = #{ id => turtle_janitor,
+                 start => {turtle_janitor, start_link, []},
+                 restart => permanent,
+                 shutdown => 5000,
+                 type => worker,
+                 modules => [turtle_janitor]
+               },
     Connectors = configure_connectors(),
-    {ok, { {one_for_one, 5, 3600}, Connectors} }.
+    {ok, { {one_for_one, 5, 3600}, [Janitor | Connectors]} }.
 
 %%====================================================================
 %% Internal functions


### PR DESCRIPTION
In the official RabbitMQ AMQP client, there is no concept of a *controlling process* common in Erlang systems. Thus, if you create a Connection, a Channel or a Consumer, there is no guarantee that it will be closed if the process creating it goes away.

In other words: you have to treat those resources as unmanaged and handle them accordingly.

Turtle currently does not manage resources at all. This leads to situations in which channels and consumers end up in a "limbo" state:

* They still exist and the AMQP server believes they are there.
* The server has already sent messages to the client (via prefetch)
* The consumer process has already forwarded the messages to the mailbox of the subscribed process.
* That process is dead, so the messages are gone. Forever.

In this situation, the messages is seen as delivered and they are then being "processed" by the client. But since they are gone, they are unlikely to ever be acked, unless one issues a faulty bulk-ack or bulk-reject by accident. Everything is dire.

This PR introduces a new `gen_server` in turtle called the `janitor`. The responsibility of the janitor is to keep track of resources and monitor processes. If a process goes away, the resources belonging to that process is also going to go away since the janitor will clean up.

Now, the only process which needs to trap exits is the `janitor`. And a lot of nasty termination paths can be removed from turtle. In short, we'll get a far more stable version of `turtle`. The downside is that this is a backwards compatibility breaking change.
