### PR TITLE
Fix the conn_sup supervision specification

### DIFF
--- a/src/turtle_sup.erl
+++ b/src/turtle_sup.erl
@@ -47,7 +47,11 @@ configure_connectors() ->
     ParamSet = turtle_config:read_params(),
     [conn_sup(Params) || Params <- ParamSet].
 
-conn_sup(#{ conn_name := Name } = Ps) ->
-    {Name,
-        {turtle_conn, start_link, [Name, Ps]},
-        permanent, infinity, supervisor, [turtle_conn_sup]}.
+conn_sup(#{conn_name := Name} = Ps) ->
+    #{ id => Name,
+       start => {turtle_conn, start_link, [Name, Ps]},
+       restart => permanent,
+       shutdown => infinity,
+       type => worker,
+       modules => [turtle_conn_sup]
+     }.

--- a/src/turtle_sup.erl
+++ b/src/turtle_sup.erl
@@ -52,6 +52,5 @@ conn_sup(#{conn_name := Name} = Ps) ->
        start => {turtle_conn, start_link, [Name, Ps]},
        restart => permanent,
        shutdown => infinity,
-       type => worker,
-       modules => [turtle_conn_sup]
+       type => worker
      }.


### PR DESCRIPTION
Fixes #34 - The turtle conn process is a worker and not a supervisor.

I have also upgraded the specification itself to the new map-based supervision specification format. This is also the format used by the janitor specification a couple of lines above, so I do not think there is any backwards compatibility concerns.