### PR TITLE
Jl/fix/heartbeat timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ sudo: false
 services:
   - rabbitmq
 
-os: linux
-otp_release: 19.3
 
 matrix:
   include:
     - os: linux
       otp_release: 19.3
     - os: linux
-      otp_release: 20.0
+      otp_release: 20.1
 
 script: "make compile test dialyzer REBAR=./rebar3"
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ become worse.
 
 # Changes
 
+* *Version 1.9.1* - Service fix
+
+    - *BUG:* If the RabbitMQ AMQP client dies, the supervision trees
+      created in applications from turtle were not correctly detecting
+      the erroneous case. This leads to a no-service situation without
+      crashing. The fix correctly monitors the AMQP clients behavior
+      and crashes appropriate parts of the supervision trees if the
+      error occurs.
+
 * *Version 1.9.0* - Important major bugfix release
 
     - *SERIOUS BUG:* The RabbitMQ AMQP client has no notion of a

--- a/src/turtle.app.src
+++ b/src/turtle.app.src
@@ -1,6 +1,6 @@
 {application, 'turtle',
  [{description, "Turtle manages RabbitMQ connections"},
-  {vsn, "1.9.0"},
+  {vsn, "1.9.1"},
   {registered, []},
   {mod, {'turtle_app', []}},
   {applications,

--- a/src/turtle_service_mgr.erl
+++ b/src/turtle_service_mgr.erl
@@ -41,9 +41,9 @@ start_link(Configuration) ->
 
 %% API
 %% ----------------------------------------------------------
-    update_configuration(ServiceName, Config)->
-        Pid = where(ServiceName),
-        gen_server:call(Pid, {config_update, ServiceName, Config}, 20*1000).
+update_configuration(ServiceName, Config)->
+    Pid = where(ServiceName),
+    gen_server:call(Pid, {config_update, ServiceName, Config}, 20*1000).
 
 
 where(ChannelName) ->
@@ -87,8 +87,7 @@ handle_cast(Cast, State) ->
     {noreply, State}.
 
 %% @private
-handle_info({gproc, Ref, registered, {_, Pid, _}}, {initializing, Ref,
-    #{ name := Name, subscriber_count := K } = Conf }) ->
+handle_info({gproc, Ref, registered, {_, Pid, _}}, {initializing, Ref, #{ name := Name, subscriber_count := K } = Conf }) ->
     {Pool, _} = gproc:await({n,l,{turtle,service_pool, Name}}, 5000),
     add_subscribers(Pool, Conf, K),
     MRef = monitor(process, Pid),

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -28,7 +28,7 @@
          invoke,
          invoke_state = init,
          handle_info = undefined,
-         channel :: pid(),
+         channel :: undefined | pid(),
          monitor :: reference(),
          consumer_tag,
          mode = single
@@ -99,7 +99,7 @@ handle_info({channel_closed, Ch, Reason}, #state { channel = Ch } = State) ->
                {shutdown, _} -> normal;
                Err -> {amqp_channel_died, Err}
            end,
-    {stop, Exit, shutdown(Exit, State#state { channel = none })};
+    {stop, Exit, shutdown(Exit, State#state { channel = undefined })};
 handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state { monitor = MRef } = State) ->
     {stop, channel_died, State};
 handle_info(Info, #state { handle_info = undefined } = State) ->

--- a/src/turtle_subscriber.erl
+++ b/src/turtle_subscriber.erl
@@ -22,16 +22,17 @@
     code_change/3
 ]).
 
--record(state, {
-	conn_name,
-	name,
-	invoke,
-	invoke_state = init,
-	handle_info = undefined,
-	channel,
-	consumer_tag,
-	mode = single
- }).
+-record(state,
+        {conn_name,
+         name,
+         invoke,
+         invoke_state = init,
+         handle_info = undefined,
+         channel :: pid(),
+         monitor :: reference(),
+         consumer_tag,
+         mode = single
+        }).
 
 %% LIFETIME MAINTENANCE
 %% ----------------------------------------------------------
@@ -50,20 +51,23 @@ init([#{
         passive := Passive,
         declarations := Decls } = Conf]) ->
     {ok, Ch} = turtle:open_channel(ConnName),
+    MRef = erlang:monitor(process, Ch),
     ok = turtle:qos(Ch, Conf),
     ok = amqp_channel:register_return_handler(Ch, self()),
     ok = turtle:declare(Ch, Decls, #{ passive => Passive }),
     {ok, Tag} = turtle:consume(Ch, Queue),
     Mode = mode(Conf),
     {ok, #state {
-        consumer_tag = Tag, 
-        invoke = Fun,
-        invoke_state = invoke_state(Conf),
-        handle_info = handle_info(Conf),
-        channel = Ch,
-        conn_name = ConnName,
-        name = Name,
-        mode = Mode }}.
+            consumer_tag = Tag, 
+            invoke = Fun,
+            invoke_state = invoke_state(Conf),
+            handle_info = handle_info(Conf),
+            channel = Ch,
+            monitor = MRef,
+            conn_name = ConnName,
+            name = Name,
+            mode = Mode
+           }}.
 
 %% @private
 handle_call(Call, From, State) ->
@@ -96,6 +100,8 @@ handle_info({channel_closed, Ch, Reason}, #state { channel = Ch } = State) ->
                Err -> {amqp_channel_died, Err}
            end,
     {stop, Exit, shutdown(Exit, State#state { channel = none })};
+handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state { monitor = MRef } = State) ->
+    {stop, channel_died, State};
 handle_info(Info, #state { handle_info = undefined } = State) ->
     lager:warning("Unknown info message: ~p", [Info]),
     {noreply, State};

--- a/src/turtle_sup.erl
+++ b/src/turtle_sup.erl
@@ -51,6 +51,6 @@ conn_sup(#{conn_name := Name} = Ps) ->
     #{ id => Name,
        start => {turtle_conn, start_link, [Name, Ps]},
        restart => permanent,
-       shutdown => infinity,
+       shutdown => 5000,
        type => worker
      }.

--- a/test/turtle_SUITE.erl
+++ b/test/turtle_SUITE.erl
@@ -516,7 +516,7 @@ kill_amqp_client(_Config) ->
     ConnPid ! heartbeat_timeout,
 
     ct:log("Service restarted, now try using it!"),
-    ct:sleep(200),
+    ct:sleep(1200),
     %% After a while, the system should have remedied itself
     #{ channel_count := 3 } = turtle_janitor:status(),
 


### PR DESCRIPTION
If the AMQP client dies under us, the supervision trees are not correctly destroyed. Fix this.