### PR TITLE
No ack support

### DIFF
--- a/src/turtle.erl
+++ b/src/turtle.erl
@@ -287,17 +287,17 @@ await(publisher, Name, Timeout) ->
 %% @doc consume/2 starts consumption on a channel with default parameters
 %% @end
 %% @private
+consume(Channel, #'basic.consume' {} = Consume) ->
+    #'basic.consume_ok' { consumer_tag = Tag } = amqp_channel:call(Channel, Consume),
+    {ok, Tag};
 consume(Channel, Queue) ->
-    consume(Channel, Queue, false).
+    consume(Channel, #'basic.consume' { queue = Queue }).
 
 %% @doc consume/3 starts consumption on a channel with default parameters
 %% @end
 %% @private
-consume(Channel, Queue, NoAck) ->
-   Sub = #'basic.consume' { queue = Queue, no_ack = NoAck },
-   #'basic.consume_ok' { consumer_tag = Tag } =
-       amqp_channel:call(Channel, Sub),
-   {ok, Tag}.
+consume(Channel, Queue, NoAck) when is_boolean(NoAck) ->
+    consume(Channel, #'basic.consume' { queue = Queue, no_ack = NoAck }).
 
 
 %% @doc cancel/2 stop consumption on a channel again.

--- a/src/turtle.erl
+++ b/src/turtle.erl
@@ -35,7 +35,7 @@
 -export([
 	declare/2, declare/3,
 	open_channel/1, open_connection/1,
-	consume/2, cancel/2,
+	consume/2, consume/3, cancel/2,
 	qos/2
 ]).
 
@@ -288,7 +288,13 @@ await(publisher, Name, Timeout) ->
 %% @end
 %% @private
 consume(Channel, Queue) ->
-   Sub = #'basic.consume' { queue = Queue },
+    consume(Channel, Queue, false).
+
+%% @doc consume/3 starts consumption on a channel with default parameters
+%% @end
+%% @private
+consume(Channel, Queue, NoAck) ->
+   Sub = #'basic.consume' { queue = Queue, no_ack = NoAck },
    #'basic.consume_ok' { consumer_tag = Tag } =
        amqp_channel:call(Channel, Sub),
    {ok, Tag}.


### PR DESCRIPTION
This pull request add possibility to enable no_ack consume option.
Motivation:
For some systems it is important to avoid storing of not acknowledged messages in RAM as it could lead to     
memory alarms which blocks all connections that are publishing messages. Also, if possible data lose is not critical or RabbitMq is used in local network and message loss is unlikely, it make sense to enable no_ack to eliminate acknowledgement overhead.

In order to use feature need to add no_ack => true to subscriber config and return ok or [] instead of ack, bulk_ack, bulk_nack, reject, remove from handler function, otherwise warning about inappropriate command in no_ack mode will be emitted  and command will be ignored.