### PR TITLE
Publisher channel

### DIFF
--- a/src/turtle_publisher.erl
+++ b/src/turtle_publisher.erl
@@ -352,7 +352,8 @@ properties(ContentType, #{}) ->
     #'P_basic' { content_type = ContentType }.
 
 %% Create a new publish package
-mk_publish(Exch, Key, ContentType, IODataPayload, Opts) ->
+mk_publish(Exch, Key, ContentType, IODataPayload, Opts) when is_binary(Exch), is_binary(Key),
+                                                             ContentType =:= undefined orelse is_binary(ContentType) ->
     Pub = #'basic.publish' {
         exchange = Exch,
         routing_key = Key

--- a/src/turtle_publisher.erl
+++ b/src/turtle_publisher.erl
@@ -221,6 +221,7 @@ handle_info({gproc, Ref, registered, {_, Pid, _}}, {initializing, N, Ref, CName,
     ok = handle_confirms(Channel, Options),
     {ok, ReplyQueue, Tag} = handle_rpc(Channel, Options),
     ConnMRef = monitor(process, Pid),
+    _ = monitor(process, Channel),
     reg(N),
     {noreply,
       #state {
@@ -240,6 +241,7 @@ handle_info({gproc, Ref, registered, {_, Pid, _}}, {initializing_takeover, N, Re
     ok = handle_confirms(Channel, Options),
     {ok, ReplyQueue, Tag} = handle_rpc(Channel, Options),
     ConnMRef = monitor(process, Pid),
+    _ = monitor(process, Channel),
     case where(N) of
         undefined ->
             reg(N);
@@ -274,6 +276,8 @@ handle_info({channel_closed, Ch, Reason}, #state { channel = Ch } = State) ->
     {stop, Exit, State};
 handle_info({'DOWN', MRef, process, _, Reason}, #state { conn_ref = MRef } = State) ->
     {stop, {error, {connection_down, Reason}}, State};
+handle_info({'DOWN', _, process, Pid, Reason}, #state { channel = Pid } = State) ->
+    {stop, {error, {channel_died, Reason}}, State};
 handle_info({'DOWN', MRef, process, _, _Reason}, #state { in_flight = IF } = State) ->
     %% Remove in-flight monitor if the RPC caller goes away
     {noreply, State#state { in_flight = track_cancel_monitor(MRef, IF) }};


### PR DESCRIPTION
Erroneous turtle:publish/5 leads to channel dying. But user doesn't know about it because this and all next turtle:publish/5 calls return ok - channel isn't t restored (as it happens in the turtle_subscriber module).